### PR TITLE
Update anatomy-of-nifti.md

### DIFF
--- a/_episodes/anatomy-of-nifti.md
+++ b/_episodes/anatomy-of-nifti.md
@@ -34,7 +34,7 @@ First, use the `load()` function to create a NiBabel image object from a NIfTI f
 We'll load in an example T1w image from the zip file we just downloaded.
 
 ~~~
-t1_img = nib.load("../data/dicom_examples/nii/0219191_mystudy-0219-1114_anat_ses-01_T1w_20190219111436_5.nii.gz")
+t1_img = nib.load("../data/dicom_examples/0219191_mystudy-0219-1114/nii/dcm_anat_ses-01_T1w_20190219111436_5.nii.gz")
 ~~~
 {: .language-python}
 


### PR DESCRIPTION
For binder environment,
correct path:
t1_img = nib.load("../data/dicom_examples/0219191_mystudy-0219-1114/nii/dcm_anat_ses-01_T1w_20190219111436_5.nii.gz")

existing path:
t1_img = nib.load("../data/dicom_examples/nii/0219191_mystudy-0219-1114_anat_ses-01_T1w_20190219111436_5.nii.gz")

reference:
https://nbviewer.jupyter.org/github/carpentries-incubator/SDC-BIDS-IntroMRI/blob/gh-pages/code/02-anatomy-of-nifti.ipynb
