### PR TITLE
Corrected a syntax error in the dcm2niix solution

### DIFF
--- a/_episodes/scanner-to-computer.md
+++ b/_episodes/scanner-to-computer.md
@@ -90,7 +90,7 @@ dcm2niix -help
 > > ## Solution
 > > ~~~
 > > mkdir -p ../data/dicom_examples/nii
-> > dcm2niix -z y -o ../data/dicom_examples/nii ../data/dicom_examples/0219191_mystudy-0219-1114/dcm
+> > dcm2niix -z y -o ../data/dicom_examples/nii ../data/dicom_examples/0219191_mystudy-0219-1114/
 > > ~~~
 > > {: .language-bash}
 > {: .solution}


### PR DESCRIPTION
the '/dcm' suffix at the end of line 93 leads to all the files being named dcm_whatever instead of 0219191_mystudy-0219-1114_whatever, which then breaks the example code on the subsequent page.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
